### PR TITLE
Add integration tests and minor fixes

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,7 +12,7 @@ checks:pylint:
   before_script:
     - sudo dnf install -y python3-gobject gtk3
   script:
-    - pylint-3 $(find ./ -type f -name '*.py')
+    - pylint-3 $(find sender receiver scripts -type f -name '*.py')
 
 include:
 - file: /r4.1/gitlab-base.yml

--- a/.pylintrc
+++ b/.pylintrc
@@ -9,6 +9,7 @@ ignore=tests
 disable=
   abstract-class-little-used,
   bad-continuation,
+  consider-using-f-string,
   cyclic-import,
   deprecated-method,
   duplicate-code,

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ BINDIR ?= /usr/bin
 DATADIR ?= /usr/share
 SYSCONFDIR ?= /etc
 QREXECDIR ?= $(SYSCONFDIR)/qubes-rpc
+PYTHON ?= python3
 
 INSTALL_DIR = install -d --
 INSTALL_PROGRAM = install -D --
@@ -18,6 +19,7 @@ help:
 	@echo "make install-dom0	Install all components necessary for dom0"
 	@echo "make install-both	Install components necessary for VMs and dom0"
 	@echo "make install-policy	Install qrexec policies"
+	@echo "make install-tests	Install integration tests"
 	@echo "make install-license	Install license to $(DATADIR)/licenses/$(PKGNAME)"
 	@echo "make clean		Clean build"
 
@@ -41,7 +43,7 @@ install-vm: install-both
 	$(INSTALL_DIR) $(DESTDIR)$(DATADIR)/$(PKGNAME)/scripts/v4l2loopback
 	$(MAKE) -C doc install
 
-install-dom0: install-both install-policy
+install-dom0: install-both install-policy install-tests
 
 install-both:
 	$(INSTALL_DIR) $(DESTDIR)$(QREXECDIR)
@@ -56,6 +58,9 @@ install-both:
 install-policy:
 	$(INSTALL_DIR) $(DESTDIR)$(QREXECDIR)/policy
 	$(INSTALL_DATA) qubes-rpc/policies/* $(DESTDIR)$(QREXECDIR)/policy
+
+install-tests:
+	cd tests && $(PYTHON) setup.py install -O1 --root $(DESTDIR)
 
 install-license:
 	$(INSTALL_DIR) $(DESTDIR)$(DATADIR)/licenses/$(PKGNAME)

--- a/debian/control
+++ b/debian/control
@@ -13,6 +13,7 @@ Depends: gir1.2-ayatanaappindicator3-0.1,
          gstreamer1.0-plugins-good,
          gstreamer1.0-tools,
          python3,
+         v4l-utils,
          v4l2loopback-dkms (>= 0.12.5-1),
          ${misc:Depends}
 Description: Securely stream webcams and share screens across virtual machines

--- a/receiver/qubes-video-companion
+++ b/receiver/qubes-video-companion
@@ -56,6 +56,5 @@ else
 fi
 
 /usr/share/qubes-video-companion/receiver/setup.sh
-# Disabling buffering should lower latency and it doesn't seem to impact performance
 # Filter standard error escape characters for safe printing to the terminal from the video sender
-qrexec-client-vm --buffer-size=0 --filter-escape-chars-stderr -- "$qube" "$qvc_service" /usr/share/qubes-video-companion/receiver/receiver.py
+qrexec-client-vm --filter-escape-chars-stderr -- "$qube" "$qvc_service" /usr/share/qubes-video-companion/receiver/receiver.py

--- a/rpm_spec/qubes-video-companion-dom0.spec.in
+++ b/rpm_spec/qubes-video-companion-dom0.spec.in
@@ -15,6 +15,8 @@ Source0:        %{vm_name}-%{version}.tar.gz
 BuildArch:      noarch
 
 BuildRequires:  make
+BuildRequires:  python3-setuptools
+BuildRequires:  python3-devel
 
 Requires:       gstreamer1-plugins-good
 
@@ -63,6 +65,8 @@ make DESTDIR=%{?buildroot} install-dom0 install-license
 %{_datadir}/qubes-video-companion/sender/webcam.py
 %{_datadir}/qubes-video-companion/sender/screenshare.py
 %{_datadir}/qubes-video-companion/sender/tray_icon.py
+%{python3_sitelib}/qvctests
+%{python3_sitelib}/qvctests-*.egg-info
 
 %changelog
 @CHANGELOG@

--- a/rpm_spec/qubes-video-companion.spec.in
+++ b/rpm_spec/qubes-video-companion.spec.in
@@ -34,6 +34,7 @@ Summary:        Video sender part of qubes-video-companion
 BuildArch:      noarch
 Requires:       gstreamer1-plugins-good
 Requires:       python3
+Requires:       v4l-utils
 Requires:       qubes-video-companion-license
 
 %description sender

--- a/sender/screenshare.py
+++ b/sender/screenshare.py
@@ -31,9 +31,10 @@ class ScreenShare(Service):
     def parameters(self) -> tuple[int, int, int]:
         monitor = Gdk.Display().get_default().get_monitor(0)
         scale, geometry = monitor.get_scale_factor(), monitor.get_geometry()
-        return (scale * geometry.width, scale * geometry.height, 30)
+        return (scale * geometry.width, scale * geometry.height, 30, {})
 
-    def pipeline(self, width: int, height: int, fps: int) -> list[str]:
+    def pipeline(self, width: int, height: int, fps: int,
+                 **kwargs) -> list[str]:
         caps = (
             "colorimetry=2:4:7:1,"
             "chroma-site=none,"

--- a/sender/service.py
+++ b/sender/service.py
@@ -64,13 +64,14 @@ class Service:
         """
         raise NotImplementedError("Pure virtual method called!")
 
-    def pipeline(self, width: int, height: int, fps: int) -> list[str]:
+    def pipeline(self, width: int, height: int, fps: int,
+                 **kwargs) -> list[str]:
         """
         Return a set-up GStreamer pipeline
         """
         raise NotImplementedError("Pure virtual method called!")
 
-    def parameters(self) -> tuple[int, int, int]:
+    def parameters(self) -> tuple[int, int, int, dict]:
         """
         Compute the parameters.  Return a (width, height, fps) tuple.
         """
@@ -120,12 +121,12 @@ class Service:
     def start_transmission(self) -> None:
         """Start video transmission"""
 
-        width, height, fps = self.parameters()
+        width, height, fps, extra_params = self.parameters()
         sys.stdout.buffer.write(struct.pack("=HHH", width, height, fps))
         sys.stdout.buffer.flush()
         Gst.init()
         element = self._element = Gst.parse_launchv(
-            self.pipeline(width, height, fps)
+            self.pipeline(width, height, fps, **extra_params)
         )
         bus = element.get_bus()
         bus.add_signal_watch()

--- a/sender/webcam.py
+++ b/sender/webcam.py
@@ -80,7 +80,7 @@ class Webcam(Service):
             "queue",
             "!",
             "capsfilter",
-            "caps=image/jpeg,colorimetry=(string)2:4:7:1,chroma-site=none,"
+            "caps=image/jpeg,chroma-site=none,"
             + caps,
             "!",
             "jpegdec",

--- a/sender/webcam.py
+++ b/sender/webcam.py
@@ -83,7 +83,17 @@ class Webcam(Service):
                 "jpegdec",
             )
         else:
-            convert = ("!", "videoconvert",)
+            convert = (
+                    "!",
+                    "videoconvert",
+                    # workaround until
+                    # https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/3713
+                    # get merged:
+                    # no-op filter that copies the frame based on its actual
+                    # size, to discard padding
+                    "!",
+                    "videoflip",
+                    )
         return [
             "v4l2src",
             "!",

--- a/tests/qvctests/integ.py
+++ b/tests/qvctests/integ.py
@@ -73,7 +73,9 @@ class TC_00_QVCTest(qubes.tests.extra.ExtraTestCase):
                            passio_popen=True)
         # wait for device to appear, or a timeout
         self.wait_for_video0(self.view)
-        self.assertIsNone(p.returncode)
+        if p.returncode is not None:
+            self.fail("'qubes-video-companion screenshare' exited early ({}): {} {}".format(
+                        p.returncode, *p.communicate()))
 
         # capture in source:
         source_image = self.capture_from_screen(self.screenshare)

--- a/tests/qvctests/integ.py
+++ b/tests/qvctests/integ.py
@@ -1,0 +1,91 @@
+from math import sqrt
+
+import qubes.tests.extra
+
+
+class TC_00_QVCTest(qubes.tests.extra.ExtraTestCase):
+    def setUp(self):
+        super(TC_00_QVCTest, self).setUp()
+        self.screenshare, self.proxy, self.view = self.create_vms(
+            ["share", "proxy", "view"])
+        self.screenshare.start()
+        if self.screenshare.run('which qubes-video-companion', wait=True) != 0:
+            self.skipTest('qubes-video-companion not installed')
+
+    def wait_for_video0(self, vm):
+        vm.run(
+            'for i in `seq 30`; do '
+            '  [ -e /dev/video0 ] && break; '
+            '  sleep 0.5; '
+            'done; sleep 1', wait=True)
+
+    def wait_for_video0_disconnect(self, vm):
+        vm.run(
+            'for i in `seq 30`; do '
+            '  ! [ -e /dev/video0 ] && break; '
+            '  sleep 0.5; '
+            'done', wait=True)
+        self.assertNotEqual(vm.run('test -e /dev/video0', wait=True), 0)
+
+    def click_stop(self, vm, name):
+        # open context menu
+        vm.run('xdotool search --onlyvisible "{}" '
+               'mousemove -w %1 5 5 '
+               'click 1'.format(name), wait=True)
+        # send keys in separate call, to not send them just to the icon window
+        vm.run('xdotool key Up Return', wait=True)
+
+    def capture_from_video(self, vm):
+        # capture in destination, use gstreamer as it is installed already:
+        gst_command = (
+            'gst-launch-1.0 --quiet v4l2src num-buffers=1 '
+            '! videoconvert '
+            '! video/x-raw,format=RGB '
+            '! fdsink'
+        )
+        return vm.run(
+            gst_command, passio_popen=True).communicate()[0]
+
+    def capture_from_screen(self, vm):
+        return vm.run(
+            'import -window root -depth 8 rgb:-', passio_popen=True)\
+            .communicate()[0]
+
+    def compare_images(self, img1, img2):
+        """Compare images (array of RGB pixels), return similarity factor -
+        the lower the better"""
+
+        assert len(img1) == len(img2)
+        sum2 = 0
+        for p1, p2 in zip(img1, img2):
+            sum2 += (p1-p2)**2
+
+        return sqrt(sum2/len(img1))
+
+    def test_010_screenshare(self):
+        self.view.start()
+        self.qrexec_policy('qvc.ScreenShare',
+                           self.view.name,
+                           '@default',
+                           target=self.screenshare.name)
+        p = self.view.run('qubes-video-companion screenshare',
+                           passio_popen=True)
+        # wait for device to appear, or a timeout
+        self.wait_for_video0(self.view)
+        self.assertIsNone(p.returncode)
+
+        # capture in source:
+        source_image = self.capture_from_screen(self.screenshare)
+        destination_image = self.capture_from_video(self.view)
+        diff = self.compare_images(source_image, destination_image)
+        self.assertLess(diff, 2.0)
+        self.click_stop(self.screenshare, 'screenshare')
+        # wait for device to disappear, or a timeout
+        self.wait_for_video0_disconnect(self.view)
+        self.assertEqual(p.wait(), 0)
+
+
+def list_tests():
+    return (
+        TC_00_QVCTest,
+    )

--- a/tests/qvctests/integ.py
+++ b/tests/qvctests/integ.py
@@ -1,3 +1,4 @@
+import unittest
 from math import sqrt
 
 import qubes.tests.extra
@@ -82,6 +83,43 @@ class TC_00_QVCTest(qubes.tests.extra.ExtraTestCase):
         self.click_stop(self.screenshare, 'screenshare')
         # wait for device to disappear, or a timeout
         self.wait_for_video0_disconnect(self.view)
+        self.assertEqual(p.wait(), 0)
+
+    # qvc.Webcam is not happy about "camera" created by qvc.ScreenShare
+    @unittest.expectedFailure
+    def test_020_webcam(self):
+        """Two stages test: screen share and then webcam
+
+        screenshare -> proxy (screenshare), then proxy -> view (webcam)
+        """
+        self.proxy.start()
+        self.view.start()
+        self.qrexec_policy('qvc.ScreenShare',
+                           self.proxy.name,
+                           '@default',
+                           target=self.screenshare.name)
+        self.qrexec_policy('qvc.Webcam',
+                           self.view.name,
+                           '@default',
+                           target=self.proxy.name)
+        p = self.proxy.run('qubes-video-companion screenshare',
+                           passio_popen=True)
+        # wait for device to appear, or a timeout
+        self.wait_for_video0(self.proxy)
+        self.assertIsNone(p.returncode)
+        p2 = self.view.run('qubes-video-companion webcam',
+                           passio_popen=True)
+        self.wait_for_video0(self.view)
+        self.assertIsNone(p2.returncode)
+
+        source_image = self.capture_from_screen(self.screenshare)
+        destination_image = self.capture_from_video(self.view)
+        diff = self.compare_images(source_image, destination_image)
+        self.assertLess(diff, 2.0)
+        self.click_stop(self.view, 'webcam')
+        self.click_stop(self.screenshare, 'screenshare')
+        self.wait_for_video0_disconnect(self.proxy)
+        self.assertEqual(p2.wait(), 0)
         self.assertEqual(p.wait(), 0)
 
 

--- a/tests/setup.py
+++ b/tests/setup.py
@@ -1,0 +1,17 @@
+import setuptools
+
+if __name__ == '__main__':
+    setuptools.setup(
+        name='qvctests',
+        version='1.0',
+        author='Invisible Things Lab',
+        author_email='marmarek@invisiblethingslab.com',
+        description='QVC tests',
+        license='MIT',
+        url='https://www.qubes-os.org/',
+        packages=['qvctests'],
+        entry_points={
+            'qubes.tests.extra.for_template':
+                'qvctests = qvctests.integ:list_tests',
+        }
+    )


### PR DESCRIPTION
The screen sharing test works (at least on Debian, where v4l2loopback-dkms is available).
But the webcam one does not. The `qvc.Webcam` service refuses to use `/dev/video0` created by `qvc.ScreenShare`, because of format incompatibility.

If I replace `jpegdec` with `videoconvert` (and drop `caps=image/jpeg` part) in sender/webcam.py, then it connects, but the output is garbage. I'm not a gstreamer expert, I'd appreciate some help here. Maybe @elliotkillick has an idea?

Separately, I tried to use it with my webcam, and it complains about `colorimetry=(string)2:4:7:1` - I needed to change it to `2:4:5:1`. Maybe this parameter can be dropped?

