### PR TITLE
Fix screenshare with multiple monitors

### DIFF
--- a/sender/screenshare.py
+++ b/sender/screenshare.py
@@ -30,12 +30,13 @@ class ScreenShare(Service):
         return "video-display"
 
     def parameters(self) -> Tuple[int, int, int]:
-        monitor = Gdk.Display().get_default().get_monitor(0)
-        scale, geometry = monitor.get_scale_factor(), monitor.get_geometry()
-        return (scale * geometry.width, scale * geometry.height, 30, {})
+        monitor = Gdk.Display().get_default().get_monitor(0).get_geometry()
+        return (monitor.width, monitor.height, 30, {})
 
     def pipeline(self, width: int, height: int, fps: int,
                  **kwargs) -> List[str]:
+        monitor = Gdk.Display().get_default().get_monitor(0).get_geometry()
+        screen = Gdk.Screen().get_default()
         caps = (
             "colorimetry=2:4:7:1,"
             "chroma-site=none,"
@@ -52,6 +53,12 @@ class ScreenShare(Service):
             "use-damage=false",
             "!",
             "queue",
+            "!",
+            "videocrop",
+            "top=" + str(monitor.y),
+            "left=" + str(monitor.x),
+            "right=" + str(screen.width() - monitor.x - monitor.width),
+            "bottom=" + str(screen.height() - monitor.y - monitor.height),
             "!",
             "capsfilter",
             "caps=video/x-raw,format=BGRx," + caps,

--- a/sender/screenshare.py
+++ b/sender/screenshare.py
@@ -31,12 +31,17 @@ class ScreenShare(Service):
 
     def parameters(self) -> Tuple[int, int, int]:
         monitor = Gdk.Display().get_default().get_monitor(0).get_geometry()
-        return (monitor.width, monitor.height, 30, {})
+        screen = Gdk.Screen().get_default()
+        kwargs = {
+            "crop_t": monitor.y,
+            "crop_l": monitor.x,
+            "crop_r": screen.width() - monitor.x - monitor.width,
+            "crop_b": screen.height() - monitor.y - monitor.height,
+        }
+        return (monitor.width, monitor.height, 30, kwargs)
 
     def pipeline(self, width: int, height: int, fps: int,
                  **kwargs) -> List[str]:
-        monitor = Gdk.Display().get_default().get_monitor(0).get_geometry()
-        screen = Gdk.Screen().get_default()
         caps = (
             "colorimetry=2:4:7:1,"
             "chroma-site=none,"
@@ -55,10 +60,10 @@ class ScreenShare(Service):
             "queue",
             "!",
             "videocrop",
-            "top=" + str(monitor.y),
-            "left=" + str(monitor.x),
-            "right=" + str(screen.width() - monitor.x - monitor.width),
-            "bottom=" + str(screen.height() - monitor.y - monitor.height),
+            "top=" + str(kwargs["crop_t"]),
+            "left=" + str(kwargs["crop_l"]),
+            "right=" + str(kwargs["crop_r"]),
+            "bottom=" + str(kwargs["crop_b"]),
             "!",
             "capsfilter",
             "caps=video/x-raw,format=BGRx," + caps,


### PR DESCRIPTION
Crops `ximagesrc` input (which is the full x11 desktop with all monitors) to fit the correct output size and position (only one monitor, with id 0 (guessing it's the default monitor)) so that `capsfilter` will accept it.

Fixes error: `gi.repository.GLib.Error: gst_parse_error: could not link queue0 to capsfilter0 (3)` (QubesOS/qubes-issues#7991)

Also removed scale factor logic since (from what I understand) it is applied after the fact and should not be considered here. Scale is monitor dependent, so calculating the position within the full X11 desktop wouldn't be possible while taking into account scaling for every single monitor, so my guess is that rendering is done with just width and height and placed within the X11 desktop with those dimentions, hence why scale should be ignored.