### PR TITLE
Export dbus address for the notification server

### DIFF
--- a/qubes-rpc/services/qvc.ScreenShare
+++ b/qubes-rpc/services/qvc.ScreenShare
@@ -1,7 +1,9 @@
 #!/bin/sh --
-
 # Copyright (C) 2021 Elliot Killick <elliotkillick@zohomail.eu>
 # Copyright (C) 2021 Demi Marie Obenour <demi@invisiblethingslab.com>
 # Licensed under the MIT License. See LICENSE file for details.
-export DISPLAY=:0
+set -eu
+true "${XDG_RUNTIME_DIR:="/run/user/$(id -u)"}"
+true "${DBUS_SESSION_BUS_ADDRESS:="unix:path=${XDG_RUNTIME_DIR}/bus"}"
+export DISPLAY=:0 XDG_RUNTIME_DIR DBUS_SESSION_BUS_ADDRESS
 exec python3 -- /usr/share/qubes-video-companion/sender/screenshare.py

--- a/qubes-rpc/services/qvc.Webcam
+++ b/qubes-rpc/services/qvc.Webcam
@@ -1,7 +1,9 @@
 #!/bin/sh --
-
 # Copyright (C) 2021 Elliot Killick <elliotkillick@zohomail.eu>
 # Copyright (C) 2021 Demi Marie Obenour <demi@invisiblethingslab.com>
 # Licensed under the MIT License. See LICENSE file for details.
-export DISPLAY=:0
-exec python3 -- /usr/share/qubes-video-companion/sender/webcam.py ${1:+"$1"}
+set -eu
+true "${XDG_RUNTIME_DIR:="/run/user/$(id -u)"}"
+true "${DBUS_SESSION_BUS_ADDRESS:="unix:path=${XDG_RUNTIME_DIR}/bus"}"
+export DISPLAY=:0 XDG_RUNTIME_DIR DBUS_SESSION_BUS_ADDRESS
+exec python3 -- /usr/share/qubes-video-companion/sender/webcam.py "${1:+"$1"}"


### PR DESCRIPTION
Only screenshare script requires as of today, but put it in webcam also for future proof as it doesn't cause any harm.

Assigning variable and declaration made separate due to ShellCheck warning SC2155.

For: https://github.com/QubesOS/qubes-issues/issues/6426
Fixes: https://github.com/QubesOS/qubes-issues/issues/8457
Fixes: https://github.com/QubesOS/qubes-video-companion/issues/15