### PR TITLE
Allow monitor choice

### DIFF
--- a/doc/qubes-video-companion.rst
+++ b/doc/qubes-video-companion.rst
@@ -20,6 +20,10 @@ The project emphasizes correctness and security all the while also sporting supe
 
 OPTIONS
 =======
+resolution
+    The video resolution to stream and receive video in. The format is [WIDTHxHEIGHTxFPS], meaning resolution is optional. If you set the environment variable "QVC_MONITOR" in the target, that monitor is going to be preferred and if not found, will fallback to the primary monitor. Example: "1920x1080x60"
+
+
 video_source
     The video source to stream and receive video from. Either "webcam" or "screenshare".
 

--- a/qubes-rpc/services/qvc.ScreenShare
+++ b/qubes-rpc/services/qvc.ScreenShare
@@ -1,7 +1,31 @@
 #!/bin/sh --
-
 # Copyright (C) 2021 Elliot Killick <elliotkillick@zohomail.eu>
 # Copyright (C) 2021 Demi Marie Obenour <demi@invisiblethingslab.com>
 # Licensed under the MIT License. See LICENSE file for details.
+
+set -eu
+
+## DISPLAY variable used by: xrandr, zenity
 export DISPLAY=:0
+
+true "${XDG_RUNTIME_DIR:="/run/user/$(id -u)"}"
+true "${DBUS_SESSION_BUS_ADDRESS="unix:path=${XDG_RUNTIME_DIR}/bus"}"
+monitors="$(xrandr --listactivemonitors \
+            | awk '/^ [0-9]+: \+/ { print "FALSE", $4, $3 }')"
+monitor_count="$(echo "${monitors}" | wc -l)"
+monitor_longest_line="$(echo "${monitors}" | wc -L)"
+dialog_height="$((monitor_count*50+60))"
+dialog_width="$((monitor_longest_line*10))"
+if test "${monitor_count}" -gt 1; then
+  # shellcheck disable=SC2086
+  QVC_MONITOR="$(zenity --list --radiolist \
+    --height="${dialog_height}" --width="${dialog_width}" \
+    --column "ID" --column "Name" --column "Resolution" \
+    --title "Screen share" \
+    --text "Select monitor to present to qube ${QREXEC_REMOTE_DOMAIN}" \
+    ${monitors})"
+fi
+true "${QVC_MONITOR:=}"
+
+export XDG_RUNTIME_DIR DBUS_SESSION_BUS_ADDRESS QVC_MONITOR
 exec python3 -- /usr/share/qubes-video-companion/sender/screenshare.py

--- a/qubes-rpc/services/qvc.Webcam
+++ b/qubes-rpc/services/qvc.Webcam
@@ -1,7 +1,9 @@
 #!/bin/sh --
-
 # Copyright (C) 2021 Elliot Killick <elliotkillick@zohomail.eu>
 # Copyright (C) 2021 Demi Marie Obenour <demi@invisiblethingslab.com>
 # Licensed under the MIT License. See LICENSE file for details.
-export DISPLAY=:0
-exec python3 -- /usr/share/qubes-video-companion/sender/webcam.py ${1:+"$1"}
+set -eu
+true "${XDG_RUNTIME_DIR:="/run/user/$(id -u)"}"
+true "${DBUS_SESSION_BUS_ADDRESS:="unix:path=${XDG_RUNTIME_DIR}/bus"}"
+export DISPLAY=:0 XDG_RUNTIME_DIR DBUS_SESSION_BUS_ADDRESS
+exec python3 -- /usr/share/qubes-video-companion/sender/webcam.py "${1:+"$1"}"

--- a/receiver/qubes-video-companion
+++ b/receiver/qubes-video-companion
@@ -12,7 +12,8 @@ unset GETOPT_COMPATIBLE
 name=${0##*/}
 
 usage() {
-    printf '%s: Usage: qubes-video-companion [--resolution=WIDTHxHEIGHTxFPS] [--] webcam|screenshare [destination qube]\n' "$name"
+    echo "Usage: $name [--resolution=[WIDTHxHEIGHTxFPS]] [--] webcam|screenshare [destination qube]" >&2
+    echo "Resolution example: 1920x1080x60"
     exit "$1"
 }
 
@@ -23,14 +24,14 @@ while :; do
     case $1 in
         -r|--resolution)
             if [[ -z "$2" ]]; then
-                printf '%s: Empty resolution argument\n' "$name"
-                usage 0
-            fi >&2
+                echo "$name: Empty resolution argument" >&2
+                usage 1
+            fi
             resolution=${2//@/+}
             resolution=${resolution//x/+}
             shift 2
             ;;
-        --help) usage 0;;
+        -h|--help) usage 0;;
         --) shift; break;;
         *) exit 1;; # cannot happen
     esac
@@ -71,7 +72,7 @@ if ! [ -f "$qvc_lock_file" ]; then
     trap exit_clean EXIT
     sudo touch "$qvc_lock_file"
 else
-    echo "Qubes Video Companion is already running! Please stop the previous session before starting a new one." >&2
+    echo "Qubes Video Companion is already running! Please stop the previous session before starting a new one. If you think this is an error, remove the lockfile $qvc_lock_file" >&2
     exit 1
 fi
 


### PR DESCRIPTION
The client can choose the monitor, which will be prompted in the Qrexec dialog. The monitor can be enforced overridden by the target by environment variable. Useful on a multi-monitor setup, especially when Dom0 is the target.

Fixes: https://github.com/QubesOS/qubes-issues/issues/9275