### PR TITLE
Add missing symbol for empty variable

### DIFF
--- a/qubes-rpc/services/qvc.ScreenShare
+++ b/qubes-rpc/services/qvc.ScreenShare
@@ -9,7 +9,7 @@ set -eu
 export DISPLAY=:0
 
 true "${XDG_RUNTIME_DIR:="/run/user/$(id -u)"}"
-true "${DBUS_SESSION_BUS_ADDRESS="unix:path=${XDG_RUNTIME_DIR}/bus"}"
+true "${DBUS_SESSION_BUS_ADDRESS:="unix:path=${XDG_RUNTIME_DIR}/bus"}"
 monitors="$(xrandr --listactivemonitors \
             | awk '/^ [0-9]+: \+/ { print "FALSE", $4, $3 }')"
 monitor_count="$(echo "${monitors}" | wc -l)"


### PR DESCRIPTION
Typo mistake, "=" only works if variable is unset while ":=" works if variable is empty or unset.