### PR TITLE
Reject `--resolution` together with `screenshare`

### DIFF
--- a/receiver/qubes-video-companion
+++ b/receiver/qubes-video-companion
@@ -67,6 +67,10 @@ case "$video_source" in
         qvc_service="qvc.Webcam"
         ;;
     screenshare)
+        if [[ -n "$resolution" ]]; then
+            echo "$name: Cannot use --resolution together with screenshare" >&2
+            exit 1
+        fi
         qvc_service="qvc.ScreenShare"
         ;;
     *)


### PR DESCRIPTION
This is an unsupported configuration, but it wasn't rejected before.

Fixes https://github.com/QubesOS/qubes-issues/issues/9523.