### PR TITLE
Allow the user to choose which webcam to use

### DIFF
--- a/sender/udev.rules
+++ b/sender/udev.rules
@@ -1,2 +1,9 @@
-# for now publish only /dev/video0
-KERNEL=="video0", RUN+="/usr/share/qubes-video-companion/sender/udev-handler"
+# Publish only the first 5 webcam/video devices:
+# - /dev/video0
+# - /dev/video2
+# - /dev/video4
+# - /dev/video6
+# - /dev/video8
+# Explanation why only even numbers are used: It seems video channels are accompanied with a metadata channel
+# e.g. /dev/video1 accompanies /dev/video0. Therefore, the second webcam's video data is at /dev/video2.
+KERNEL=="video[02468]", RUN+="/usr/share/qubes-video-companion/sender/udev-handler"

--- a/sender/webcam.py
+++ b/sender/webcam.py
@@ -23,8 +23,12 @@ class Webcam(Service):
     untrusted_requested_fps: int
 
     def __init__(self, *, untrusted_arg: str):
-        self.port_id = "dev-video0"
+        #self.port_id = "dev-video0"
+        # By default use the port id with highest number from QubesDB
+        self.port_id = self.get_highest_port_id()
 
+        # However, if an argument is used, check if it starts with dev and if
+        # so, use it as the port id
         if untrusted_arg:
             if untrusted_arg.startswith("dev-"):
                 # first arg may be a port id, and then optional resolution arg
@@ -35,11 +39,12 @@ class Webcam(Service):
                 else:
                     untrusted_port_id, untrusted_arg = untrusted_arg, None
 
-                # currently support only a single port: "dev-video0"
-                if untrusted_port_id != "dev-video0":
+                supported_port_ids = ["dev-video0", "dev-video2", "dev-video4", "dev-video6", "dev-video8"]
+                if untrusted_port_id not in supported_port_ids:
                     print(f"Unsupported webcam port ({untrusted_port_id}), "
-                           "only 'dev-video0' supported", file=sys.stderr)
+                           "only 'dev-video0/2/4/6/8' supported", file=sys.stderr)
                 self.port_id = untrusted_port_id
+
 
         if untrusted_arg:
             def parse_int(untrusted_decimal: bytes) -> int:
@@ -95,7 +100,7 @@ class Webcam(Service):
             rb"fps\)\Z"
         )
         proc = subprocess.run(
-            ("v4l2-ctl", "--list-formats-ext"),
+            ("v4l2-ctl", "--list-formats-ext", f"--device=/dev/video{self.port_id[-1]}"),
             stdout=subprocess.PIPE,
             check=True,
             env={"PATH": "/bin:/usr/bin", "LC_ALL": "C"},
@@ -165,6 +170,7 @@ class Webcam(Service):
                     )
         return [
             "v4l2src",
+            f"device=/dev/video{self.port_id[-1]}",
             "!",
             "queue",
             *convert,
@@ -191,6 +197,17 @@ class Webcam(Service):
         qdb.write(f"/webcam-devices/{self.port_id}/connected-to", remote_domain)
         qdb.write("/webcam-devices", "")
         atexit.register(self._cleanup_connect_state)
+
+    def get_highest_port_id(self):
+        qdb = qubesdb.QubesDB()
+        qdb_device_entries = qdb.list("/webcam-devices")
+        port_ids = []
+        pattern = r"(?:/webcam-devices/dev-video)(\d{1})(?:/connected-to)"
+        for entry in qdb_device_entries:
+            match = re.search(pattern, entry)
+            if match:
+                port_ids.append(int(match.group(1)))
+        return f"dev-video{str(max(port_ids))}"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes https://github.com/QubesOS/qubes-issues/issues/9614

In prinicple it seems to work but I still want to do some thorough testing. Especially with my GrapheneOS Pixel 8a as a Webcam there are some problems (sudden disconnects, I can't select in OBS, ...) that I haven't yet figured out. 

Also, still missing in my current approach are:

- Handling command line arguments that specify a port id that is not currently connected
- A way to specify the port id when starting qubes-video-companion via the apps menu ("Receive Webcam")
- Test cases