### PR TITLE
Allow single-letter qube names in Qubes Video Companion

### DIFF
--- a/sender/service.py
+++ b/sender/service.py
@@ -111,7 +111,7 @@ class Service:
     def validate_qube_names(target_domain: str, remote_domain: str) -> NoReturn:
         import re
 
-        qube_re = re.compile("^[A-Za-z][A-Za-z0-9_-]{1,30}$")
+        qube_re = re.compile("^[A-Za-z][A-Za-z0-9_-]{0,30}$")
         if not qube_re.match(target_domain):
             print(
                 "Invalid target qube name %r, failing" % target_domain,

--- a/sender/service.py
+++ b/sender/service.py
@@ -111,7 +111,7 @@ class Service:
     def validate_qube_names(target_domain: str, remote_domain: str) -> NoReturn:
         import re
 
-        qube_re = re.compile("^[A-Za-z][A-Za-z0-9_-]{0,30}$")
+        qube_re = re.compile(r"\A[A-Za-z][A-Za-z0-9_-]{0,30}\Z")
         if not qube_re.match(target_domain):
             print(
                 "Invalid target qube name %r, failing" % target_domain,


### PR DESCRIPTION
## Summary

- Allow one-character qube names in sender validation.
- Keep the existing character set and maximum-length limit unchanged.

Fixes QubesOS/qubes-issues#10872.

AI assistance disclosure: AI assistance was used to inspect the issue, implement this change, and draft this pull request.