### PR TITLE
Remove obsolete v4l2loopback patch note

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,6 @@ This project is the product of an independent effort that is not officially endo
 - [Cheese](https://wiki.gnome.org/Apps/Cheese)
 - Chromium-based browsers (e.g. Brave and Google Chrome)
 - Firefox
-    - This [patch](https://github.com/umlaeute/v4l2loopback/pull/435) for `v4l2loopback` is necessary to get this working
 - Open Broadcaster Software (OBS)
     - For the `Video Capture Device (V4L2)` source click on the `Properties` settings cog and use video format `Planar YUV 4:2:0` (as opposed to `YV12 (Emulated)`) and uncheck `Use buffering` for optimal performance
 - Zoom


### PR DESCRIPTION
Remove the note claiming that Firefox requires v4l2loopback PR #435.

The linked upstream change was never merged, and v4l2loopback maintainers closed it as obsolete after the original reporter confirmed that Firefox worked with the current upstream code.