### PR TITLE
Add Arch Linux VM packaging

### DIFF
--- a/.qubesbuilder
+++ b/.qubesbuilder
@@ -9,3 +9,6 @@ vm:
   deb:
     build:
     - debian
+  archlinux:
+    build:
+    - archlinux

--- a/Makefile.builder
+++ b/Makefile.builder
@@ -5,3 +5,22 @@ RPM_SPEC_FILES := rpm_spec/qubes-video-companion-dom0.spec
 endif
 
 DEBIAN_BUILD_DIRS := debian
+
+ifeq ($(PACKAGE_SET),vm)
+ARCH_BUILD_DIRS := archlinux
+endif
+
+# Support for new packaging
+ifneq ($(filter $(DISTRIBUTION), archlinux),)
+VERSION := $(file <$(ORIG_SRC)/$(DIST_SRC)/version)
+GIT_TARBALL_NAME ?= qubes-video-companion-$(VERSION)-1.tar.gz
+SOURCE_COPY_IN := source-archlinux-copy-in
+
+source-archlinux-copy-in: PKGBUILD = $(CHROOT_DIR)/$(DIST_SRC)/$(ARCH_BUILD_DIRS)/PKGBUILD
+source-archlinux-copy-in:
+	cp $(PKGBUILD).in $(CHROOT_DIR)/$(DIST_SRC)/PKGBUILD
+	sed -i "s/@VERSION@/$(VERSION)/g" $(CHROOT_DIR)/$(DIST_SRC)/PKGBUILD
+	sed -i "s/@REL@/1/g" $(CHROOT_DIR)/$(DIST_SRC)/PKGBUILD
+endif
+
+# vim: filetype=make

--- a/archlinux/PKGBUILD.in
+++ b/archlinux/PKGBUILD.in
@@ -1,0 +1,47 @@
+# The Qubes OS Project, https://www.qubes-os.org
+
+pkgname=qubes-video-companion
+pkgver=@VERSION@
+pkgrel=@REL@
+pkgdesc="Securely stream webcams and share screens across Qubes OS virtual machines"
+arch=(any)
+url="https://github.com/QubesOS/qubes-video-companion"
+license=(MIT)
+depends=(
+    acl
+    bash
+    gst-plugins-good
+    gstreamer
+    libayatana-appindicator
+    libnotify
+    notification-daemon
+    python
+    python-gobject
+    qubes-db-vm
+    qubes-vm-qrexec
+    sudo
+    systemd
+    v4l-utils
+)
+makedepends=(
+    make
+    pandoc-cli
+)
+optdepends=(
+    'v4l2loopback-dkms: video receiver support when using an in-VM kernel'
+)
+_pkgnvr="${pkgname}-${pkgver}-${pkgrel}"
+source=("${_pkgnvr}.tar.gz")
+sha256sums=(SKIP)
+
+build() {
+    cd "${_pkgnvr}"
+    make build
+}
+
+package() {
+    cd "${_pkgnvr}"
+    make DESTDIR="${pkgdir}" install-vm install-license
+}
+
+# vim:set ts=4 sw=4 et:


### PR DESCRIPTION
## Summary

- add an Arch Linux PKGBUILD for the VM sender and receiver components
- register the Arch package with current and legacy Qubes builder metadata
- document v4l2loopback DKMS as optional when using an in-VM kernel

AI assistance was used during development of this change.